### PR TITLE
Add fields for invoice & credit note account

### DIFF
--- a/view/sale_channel_form.xml
+++ b/view/sale_channel_form.xml
@@ -80,6 +80,10 @@
             <field name="order_states" colspan="6"/>
         </page>
         <page string="Taxes" id="taxes">
+            <label name="invoice_account"/>
+            <field name="invoice_account"/>
+            <label name="credit_note_account"/>
+            <field name="credit_note_account"/>
             <field name="taxes" colspan="4"/>
         </page>
     </notebook>


### PR DESCRIPTION
These fields can be used to pick default values for
accounts setup in categories, taxes, etc.
Also, introduce default keyword arg 'silent' in 'get_tax'
method which will aid in creating taxes in downstream modules.
[#136117271]