### PR TITLE
Don't auto assign shipments

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -332,7 +332,6 @@ class Sale:
         :param channel_state: State on external channel the order was imported.
         """
         Sale = Pool().get('sale.sale')
-        Shipment = Pool().get('stock.shipment.out')
 
         data = self.channel.get_tryton_action(channel_state)
 
@@ -350,11 +349,6 @@ class Sale:
         if data['action'] == 'process_automatically' and \
                 self.state == 'confirmed':
             Sale.process([self])
-            for shipment in self.shipments:
-                if shipment.state == 'draft':
-                    Shipment.wait([shipment])
-                if shipment.state == 'waiting':
-                    Shipment.assign_try([shipment])
 
         if data['action'] == 'import_as_past' and self.state == 'draft':
             # XXX: mark past orders as completed


### PR DESCRIPTION
Auto assigning shipments causes the most recent orders
to get inventory first and old orders later
[FP-2537]